### PR TITLE
Use commit SHA instead of version tag in auto-author-assign workflow

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -11,4 +11,4 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v2.1.1
+      - uses: toshimaru/auto-author-assign@16f0022cf3d7970c106d8d1105f75a1165edb516 # v2.1.1


### PR DESCRIPTION
Replace version tag v2.1.1 with commit SHA 16f0022cf3d7970c106d8d1105f75a1165edb516 for better security practices as suggested in code review.